### PR TITLE
Fix: Allow Google Sign-In in CSP and fix date validation timezone bug

### DIFF
--- a/middleware/security.js
+++ b/middleware/security.js
@@ -12,8 +12,8 @@ const securityMiddleware = helmet({
       styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://fonts.googleapis.com'],
       fontSrc: ['\'self\'', 'https://fonts.gstatic.com'],
       imgSrc: ['\'self\'', 'data:', 'https:'],
-      scriptSrc: ['\'self\'', 'https://maps.googleapis.com'],
-      connectSrc: ['\'self\'', 'https://maps.googleapis.com'],
+      scriptSrc: ['\'self\'', 'https://maps.googleapis.com', 'https://accounts.google.com'],
+      connectSrc: ['\'self\'', 'https://maps.googleapis.com', 'https://accounts.google.com'],
       frameSrc: ['\'none\''],
       objectSrc: ['\'none\''],
       upgradeInsecureRequests: []

--- a/tests/e2e/basic-flow.test.js
+++ b/tests/e2e/basic-flow.test.js
@@ -129,7 +129,7 @@ describe('🧪 Basic Tabsur App Flow Tests', () => {
       const validateMealDate = (dateString) => {
         const mealDate = new Date(dateString);
         const today = new Date();
-        today.setHours(0, 0, 0, 0);
+        today.setUTCHours(0, 0, 0, 0);
 
         return mealDate >= today;
       };


### PR DESCRIPTION
## Summary

- **CSP**: Add `https://accounts.google.com` to `script-src` and `connect-src` in `middleware/security.js` — the Google Identity Services script (`gsi/client`) was being blocked, preventing Google Sign-In from loading
- **Test**: Fix timezone bug in `validateMealDate` test — `new Date("YYYY-MM-DD")` parses date-only strings as UTC midnight, so the comparison target must use `setUTCHours` (not `setHours`) to avoid failures near midnight in non-UTC timezones

## Test plan

- [ ] Google Sign-In button loads without CSP errors in browser console
- [ ] `npm test` passes (all 94 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)