### PR TITLE
Fix: Correct multiple bugs in API route handlers

### DIFF
--- a/routes/api/attends.js
+++ b/routes/api/attends.js
@@ -69,7 +69,7 @@ router.post('/:id', authenticateJWT, async (req, response) => {
 });
 /* UPDATE attend */
 router.put('/:id', authenticateJWT, function (req, response) {
-  return response.status(500).json('failed to update - not implemented');
+  return response.status(501).json({ error: 'Not implemented' });
 });
 /* DELETE attend */
 router.delete('/:id', authenticateJWT, async (req, response) => {
@@ -80,8 +80,8 @@ router.delete('/:id', authenticateJWT, async (req, response) => {
   client.query(`DELETE FROM attends WHERE
   meal_id = $1 AND user_id=$2`,
   [attend.meal_id, attend.user_id])
-    .catch(err => { console.error(err); return response.status(500).json('failed to delete'); })
-    .then(answer => { return response.status(201).json(answer); })
+    .then(() => { return response.status(200).json({ deleted: true }); })
+    .catch(err => { console.error(err); return response.status(500).json({ error: 'Failed to delete' }); })
     .finally(() => client.release());
 });
 module.exports = router;

--- a/routes/api/follow.js
+++ b/routes/api/follow.js
@@ -67,7 +67,7 @@ router.post('/:id', authenticateJWT, async (req, response) => {
   VALUES ($1, $2, $3)
   ON CONFLICT (follower, followie)
   DO UPDATE SET
-  status = $3 WHERE follow.follower=$2 AND follow.followie = $1
+  status = $3 WHERE follow.follower=$1 AND follow.followie = $2
   RETURNING follower`;
   console.log(JSON.stringify(SQLquery));
   const client = await pool.connect();

--- a/routes/api/hungry.js
+++ b/routes/api/hungry.js
@@ -77,18 +77,7 @@ router.post('/', authenticateJWT, async (req, response) => {
     [hungry.user, hungry.name, hungry.type, `(${hungry.location.lng}, ${hungry.location.lat})`,
       hungry.address, hungry.date, hungry.until, hungry.visibility])
     .then((res) => {
-      console.log(`query done: ${JSON.stringify(res.rows)}`);
-      // const message = {
-      //   title: 'Somebody is hungry here',
-      //   body:  `A hungry user in your area!`,
-      //   icon: 'resources/Message-Bubble-icon.png',
-      //   click_action: `/User/${hungry.user}`,
-      //   receiver: hungry.user,
-      //   meal_id:  -1,
-      //   sender: -1,
-      //   type: 7
-      // };
-      // addNotification(message);
+      return response.status(201).json(res.rows[0]);
     })
     .catch((e) => {
       console.error('exception catched: ' + e);
@@ -113,8 +102,7 @@ router.delete('/:hungry_id', authenticateJWT, async (req, response) => {
   client.query('DELETE FROM hungry WHERE id=$1',
     [hungry_id])
     .then(() => {
-      console.log('deleted.');
-      return response.status(201).json(req.body);
+      return response.status(200).json({ deleted: hungry_id });
     })
     .catch((e) => {
       console.error('exception catched: ' + e);

--- a/routes/api/images.js
+++ b/routes/api/images.js
@@ -2,7 +2,6 @@ const express = require('express');
 const { S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
 const fs = require('fs');
 const keys = require('../../config/keys');
-// const fileType = require('file-type');
 const multiparty = require('multiparty');
 const insertImageIntoDB = require('./utility.js');
 const router = express.Router();
@@ -42,7 +41,7 @@ router.post('/upload', authenticateJWT, async (request, response) => {
     console.log(`Uploading file: ${JSON.stringify(files)}`);
     const path = files.file[0].path;
     const buffer = fs.readFileSync(path);
-    const type = 'jpeg'; //await fileType(buffer);
+    const type = 'jpeg';
     const timestamp = Date.now().toString();
     const fileName = `images/${timestamp}-lg`;
     const uploader = fields.uploader;

--- a/routes/api/meals.js
+++ b/routes/api/meals.js
@@ -2,8 +2,8 @@ const pool = require('../db.js');
 const { authenticateJWT, tryAuthenticateJWT } = require('../authenticateJWT.js');
 const express = require('express');
 const router = express.Router();
-// Load input validation;
 const validateMealInput = require('../../validation/meal');
+const { validateMealUpdate } = require('../../validation/meal');
 // @route GET api/meals/public
 // @desc get public meals for unauthenticated users;
 // @access Public;
@@ -266,11 +266,7 @@ router.post('/', authenticateJWT, async (req, response) => {
     });
 });
 router.put('/', authenticateJWT, async (req, response) => {
-  // console.error(`Editing meal is not implemented yet ${JSON.stringify(req.body)}`);
   const meal = req.body;
-
-  // Use the flexible update validation
-  const { validateMealUpdate } = require('../../validation/meal');
   const { errors, isValid } = validateMealUpdate(meal);
 
   // Check validation;
@@ -312,12 +308,11 @@ router.delete('/:meal_id', authenticateJWT, async (req, response) => {
   client.query('DELETE FROM meals WHERE id=$1',
     [mealId])
     .then(() => {
-      console.log('deleted.');
-      return response.status(201).json(req.body);
+      return response.status(200).json({ deleted: mealId });
     })
     .catch(e => {
-      console.error(`Exception catched: ${JSON.stringfy(e)}`);
-      response.status(500).json(e);
+      console.error(`Exception in deleting meal: ${JSON.stringify(e)}`);
+      response.status(500).json({ error: 'Failed to delete meal' });
     })
     .finally(() => {
       client.release();

--- a/routes/api/notifications.js
+++ b/routes/api/notifications.js
@@ -61,7 +61,7 @@ router.post('/token/:id', authenticateJWT, async (req, response)=> {
   INSERT INTO user_tokens (user_id, token_type, token)
   SELECT $1, 0, $2
   WHERE NOT EXISTS (
-    SELECT 1 FROM user_tokens WHERE user_id=$3 AND token=$4;
+    SELECT 1 FROM user_tokens WHERE user_id=$3 AND token=$4
   )
   RETURNING token`;
   const client = await pool.connect();

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -3,14 +3,10 @@ const router = express.Router();
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const keys = require('../../config/keys');
-//const passport = require('passport');
 const insertImageIntoDB = require('./utility.js');
 const pool = require('../db.js');
-// Load input validation;
 const validateRegisterInput = require('../../validation/register');
 const validateLoginInput = require('../../validation/login');
-// Load User model;
-//const User = require('../../models/User');
 // @route POST api/users/register;
 // @desc Register user;
 // @access Public;
@@ -57,8 +53,8 @@ router.post('/register', async (req, response) => {
     });
   }
   catch (e) {
-    console.log('exception catched: ' + e);
-    return response.status(500).json(req.body);
+    console.error('register exception: ' + e);
+    return response.status(500).json({ error: 'Registration failed' });
   }
 });
 // @route POST api/users/login;
@@ -77,50 +73,28 @@ router.post('/login', async (req, response) => {
   client.query('SELECT id, name, password FROM users WHERE email = $1 OR id = $2 LIMIT 1',
     [newReq.email, newReq.id])
     .then(res => {
-    // no record found
       if (res.rows === undefined || res.rows.length === 0) {
         console.error(`error: user [${newReq.email}] doesn't exist.`);
         errors.email = 'email not found';
-        return response.status(500).json(errors);
+        return response.status(404).json(errors);
       }
-      // Check password;
       const row = res.rows[0];
-      console.log('res: ' + JSON.stringify(res));
-      console.log('row: ' + JSON.stringify(row));
-      bcrypt.compare(newReq.password, row.password).then(isMatch => {
+      return bcrypt.compare(newReq.password, row.password).then(isMatch => {
         if (isMatch) {
-        // User matched;
-        // Create JWT Payload;
-          const payload = {
-            id: row.id,
-            name: row.name
-          };
-          // Sign token;
-          jwt.sign(
-            payload,
-            keys.secretOrKey,
-            {
-              expiresIn: 31556926 // 1 year in seconds
-            },
-            (err, token) => {
-              response.json({
-                success: true,
-                token: 'Bearer ' + token
-              });
-            }
-          );
+          const payload = { id: row.id, name: row.name };
+          jwt.sign(payload, keys.secretOrKey, { expiresIn: 31556926 }, (err, token) => {
+            response.json({ success: true, token: 'Bearer ' + token });
+          });
         } else {
-          return response
-            .status(400)
-            .json({ passwordincorrect: 'Password incorrect' });
+          return response.status(400).json({ passwordincorrect: 'Password incorrect' });
         }
-      })
-        .catch(err => {
-          console.error('bcrypt error:' + err);
-          return response.status(500).json(newReq);
-        })
-        .finally(() => client.release());
-    });
+      });
+    })
+    .catch(err => {
+      console.error('login error:' + err);
+      return response.status(500).json({ error: 'Login failed' });
+    })
+    .finally(() => client.release());
 });
 //add avatar path to images and update user_images table;
 const addAvatar = async (client, userId, picture) => {
@@ -158,7 +132,7 @@ router.post('/loginFB', async (req, response) => {
   const newReq = req.body;
   if (!newReq || !newReq.name) {
     console.error(`Bad request to login with facebook: ${JSON.stringify(newReq)}`);
-    return response.status(403);
+    return response.status(400).json({ error: 'Invalid Facebook login request' });
   }
   let newUserId = -1;
   const newUserName = newReq.name;


### PR DESCRIPTION
## Summary

Seven bugs fixed across the API route layer — none visible in normal testing but all cause real failures under specific conditions.

### Critical bugs

| File | Bug | Impact |
|------|-----|--------|
| `hungry.js` POST | Missing `response.json()` on success | All POST /hungry requests **hung forever** — no response ever sent |
| `users.js` loginFB | `response.status(403)` without `.json()`/`.end()` | Bad FB login requests **hung forever** |
| `attends.js` DELETE | `.catch()` before `.then()` (inverted) | On DB error: catch sent 500, then `.then()` ran and tried to send another response → double-response crash |
| `follow.js` | `$1`/`$2` swapped in `ON CONFLICT WHERE` clause | Follow/unfollow UPDATE **never applied** — conflict was always ignored silently |
| `notifications.js` | Semicolon inside SQL subquery string | `INSERT /token` endpoint always threw a PostgreSQL parse error |

### Other fixes

- `meals.js`: `JSON.stringfy()` → `JSON.stringify()` typo (threw on delete errors); moved `validateMealUpdate` require to top of file; DELETE returns 200 not 201
- `users.js` login: missing `.catch()` on outer SELECT query → connection pool leak on DB error; `req.body` removed from 500 responses (data exposure)
- `attends.js` PUT: 500 → 501 Not Implemented
- `hungry.js` DELETE: 201 → 200
- `images.js`: removed commented-out dead code (`fileType`)
- `users.js`: removed commented-out dead imports (`passport`, `User`)

## Test plan

- [ ] POST `/api/hungry` now returns 201 with the new record
- [ ] POST `/api/users/loginFB` with missing `name` field now returns 400
- [ ] DELETE `/api/attends/:id` returns 200 (not crash on error)
- [ ] Follow/unfollow now correctly updates existing rows
- [ ] POST `/api/notifications/token/:id` no longer throws SQL parse error
- [ ] Server lint: `npm run lint:server` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)