### PR TITLE
Deps: Upgrade dotenv ^8 → ^17

### DIFF
--- a/config/keys.js
+++ b/config/keys.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').config({ quiet: true });
 
 module.exports = {
   google: process.env.GOOGLE_API_KEY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "compression": "^1.8.1",
         "cors": "^2.8.5",
         "dompurify": "^3.4.0",
-        "dotenv": "^8.2.0",
+        "dotenv": "^17.4.2",
         "express": "^4.17.1",
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.1.0",
@@ -11011,12 +11011,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",
     "cors": "^2.8.5",
-    "dotenv": "^8.2.0",
+    "dotenv": "^17.4.2",
     "express": "^4.17.1",
     "express-rate-limit": "^8.5.1",
     "helmet": "^8.1.0",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').config({ quiet: true });
 const express = require('express');
 const path = require('path');
 const cors = require('cors');


### PR DESCRIPTION
## Summary

- Bumps `dotenv` from `^8.2.0` to `^17.4.2` (9 major versions)
- Adds `{ quiet: true }` to both `require('dotenv').config()` call sites (`server.js`, `config/keys.js`) to suppress v17's new default console logging

## Breaking changes reviewed

The only API in use is `require('dotenv').config()` — no advanced options, no multiline values, no vault/DOTENV_KEY usage. All 9 major version changes were additive (vault support, `populate()` method, `processEnv` option, etc.).

The only behavioral change that would affect this project is v17's new default logging (`◇ injected env (N) from .env`). Fixed with `quiet: true`.

## Test plan

- [x] `node -e "require('./server.js')"` → clean startup, no dotenv console output
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run lint:server` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)