### PR TITLE
fix(client): create-meal wizard crash — react-step-wizard CJS interop under Vite

### DIFF
--- a/client/src/components/meals/CreateMeal/CreateMealWizard.jsx
+++ b/client/src/components/meals/CreateMeal/CreateMealWizard.jsx
@@ -7,7 +7,7 @@ import ImageStep from './ImageStep';
 
 import PropTypes from "prop-types";
 import Navigator from "./Navigator";
-import StepWizard from 'react-step-wizard';
+import StepWizardImport from 'react-step-wizard';
 import { connect } from "react-redux";
 import { addMeal } from "../../../actions/mealActions";
 import BackBarMui from "../../layout/BackBarMui";
@@ -16,6 +16,10 @@ import Box from '@mui/material/Box';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
+
+// react-step-wizard is CJS; under Vite the default import can resolve to the
+// module namespace object instead of the component, so unwrap .default.
+const StepWizard = StepWizardImport.default || StepWizardImport;
 
 
 const CreateMealWizard = ({ auth, addMeal }) => {


### PR DESCRIPTION
## Found via smoke-testing the migration
While smoke-testing the swipe tabs and address autocomplete (post React 19 / Vite migration), navigating to **/createMealWizard** crashed into the ErrorBoundary:

> `Element type is invalid ... got: object. Check the render method of CreateMealWizard.`

## Root cause
`react-step-wizard` is CJS; its `module.exports` is `{ Step, default: <component> }`. Under Vite's ESM/CJS interop, `import StepWizard from 'react-step-wizard'` resolved to the **namespace object** rather than the component, so `<StepWizard>` was an object → invalid element.

webpack handled this interop differently, so it only broke after the **Phase 1 Vite migration**. It stayed hidden because:
- the `CreateMealWizard` test **mocks** `react-step-wizard`, and
- there was no browser smoke test until now.

The whole create-meal flow was crashing.

## Fix
Import the namespace and unwrap `.default`:
```js
import StepWizardImport from 'react-step-wizard';
const StepWizard = StepWizardImport.default || StepWizardImport;
```

## Verification (headless browser + checks)
- ✅ `/createMealWizard` renders the full wizard; the address autocomplete input mounts; **no page errors**
- ✅ Swipe tabs confirmed working (`translateX` 0% → -25% → -75% on tab change)
- ✅ `vite build` OK · `lint` 0 errors · `npm test` 34 passed / 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)