### PR TITLE
fix(client): create-meal wizard infinite render loop + re-enable wizard tests

### DIFF
--- a/client/src/components/meals/CreateMeal/CreateMealWizard.jsx
+++ b/client/src/components/meals/CreateMeal/CreateMealWizard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import useHistory from "../../../utils/useHistory";
 import NameStep from './NameStep';
 import LocationStep from './LocationStep';
@@ -61,17 +61,18 @@ const CreateMealWizard = ({ auth, addMeal }) => {
     uploadingState: false
   });
 
-  const setInstance = SW => updateState({
-    ...state,
-    SW,
-  });
+  // Stable callbacks: react-step-wizard re-invokes `instance`, and the location
+  // step's map effect depends on `update`'s identity — if these change every
+  // render they cause an infinite update loop ("Maximum update depth exceeded").
+  // useCallback + functional updates keep their identity stable; setInstance
+  // also bails when the SW reference is unchanged.
+  const setInstance = useCallback((SW) => {
+    updateState(prev => (prev.SW === SW ? prev : { ...prev, SW }));
+  }, []);
 
-  const onStepChange = (stats) => {
-    updateState({
-      ...state,
-      stats
-    });
-  };
+  const onStepChange = useCallback((stats) => {
+    updateState(prev => ({ ...prev, stats }));
+  }, []);
 
   const submit = (e) => {
     e.preventDefault();
@@ -97,19 +98,13 @@ const CreateMealWizard = ({ auth, addMeal }) => {
       history.push({ pathname: '/', hash: '#2' });
     });
   }
-  const update = (e) => {
-    const { form } = state;
+  const update = useCallback((e) => {
+    updateState(prev => ({ ...prev, form: { ...prev.form, [e.id]: e.value } }));
+  }, []);
 
-    form[e.id] = e.value;
-    updateState({
-      ...state,
-      form,
-    });
-  };
-
-  const setUploadingState = (newUploadingState) => {
-    updateState({ ...state, uploadingState: newUploadingState });
-  }
+  const setUploadingState = useCallback((newUploadingState) => {
+    updateState(prev => ({ ...prev, uploadingState: newUploadingState }));
+  }, []);
   const { SW } = state;
 
   return (

--- a/client/src/components/meals/CreateMeal/LocationStep.jsx
+++ b/client/src/components/meals/CreateMeal/LocationStep.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import MapLocationSelector from "./../MapLocationSelector";
 import { TextField, Grid, Box } from '@mui/material';
 const LocationStep = props => {
@@ -7,13 +7,16 @@ const LocationStep = props => {
   const defaultLocationConst = { lng: 34.808, lat: 32.09 };
 
   const [defaultLocation, updateDefaultLocation] = useState(defaultLocationConst);
-  const onLocationUpdate = ({ address, location }) => {
-    props.update({ "id": "address", "value": address });
-    props.update({ "id": "location", "value": location });
+  // Stable identity so MapLocationSelector's mount effect (which depends on
+  // this callback) doesn't re-run every render -> infinite update loop.
+  const { update } = props;
+  const onLocationUpdate = useCallback(({ address, location }) => {
+    update({ "id": "address", "value": address });
+    update({ "id": "location", "value": location });
     console.log(`onLocationUpdate: ${address}; location: ${JSON.stringify(location)}`);
     setAddress(address);
     updateDefaultLocation(location);
-  };
+  }, [update]);
 
   const onMapExit = (e) => {
     console.log(`Exit map clicked: ${showMap}.`);

--- a/client/src/components/meals/CreateMeal/__tests__/CreateMealWizard.test.jsx
+++ b/client/src/components/meals/CreateMeal/__tests__/CreateMealWizard.test.jsx
@@ -17,6 +17,20 @@ vi.mock('axios', () => ({
   }
 }));
 
+// The wizard deep-renders the location step's map; stub the Google Maps layer
+// so jsdom doesn't hit `google is not defined`.
+vi.mock('@react-google-maps/api', () => ({
+  GoogleMap: ({ children }) => <div data-testid="google-map">{children}</div>,
+  Marker: (props) => <div data-testid="map-marker" {...props} />,
+  LoadScript: ({ children }) => <div>{children}</div>,
+  Autocomplete: ({ children }) => <div data-testid="places-autocomplete">{children}</div>
+}));
+vi.mock('react-geocode', () => ({
+  setDefaults: vi.fn(),
+  fromLatLng: vi.fn(),
+  fromAddress: vi.fn()
+}));
+
 
 // Mock the StepWizard component
 vi.mock('react-step-wizard', () => ({
@@ -102,12 +116,7 @@ const renderWithProviders = (component, initialState = {}) => {
   );
 };
 
-// TODO(vite-migration): this suite renders the full multi-step wizard, whose
-// deep map dependencies (GoogleMap / Google Places) either throw in jsdom or, when
-// stubbed, trigger an infinite render loop in the step logic. It was already
-// non-running under the old CRA jest setup. Skipped until the wizard is given a
-// properly isolated harness (mock LocationStep / the step components directly).
-describe.skip('CreateMealWizard', () => {
+describe('CreateMealWizard', () => {
   const mockAuthState = {
     isAuthenticated: true,
     user: {


### PR DESCRIPTION
## The bug
The create-meal wizard logged **`Maximum update depth exceeded`** in the browser (surfaced once #265 made the wizard render). Infinite render loop.

## Root cause
The wizard's callbacks (`update`, `setInstance`, …) were recreated on every render. `update` flows down `CreateMealWizard → LocationStep.onLocationUpdate → MapLocationSelector` as `handleLocationUpdate`, whose **geolocation `useEffect` has `[handleLocationUpdate]` as its dependency**. Since the callback's identity changed every render, the effect re-ran every render → called the callback → `setState` → re-render → ∞. (Exactly the React warning: "a dependency changes on every render".)

## Fix — stabilize the callback chain
- **CreateMealWizard**: `useCallback` + functional state updates for `update` / `onStepChange` / `setUploadingState`. `setInstance` is memoized **and bails when the StepWizard ref is unchanged** (defends against `react-step-wizard` re-invoking `instance`). Also fixes a latent state-mutation bug in `update`.
- **LocationStep**: `useCallback` for `onLocationUpdate`.

With stable identities, `MapLocationSelector`'s mount effect runs **once**.

## Bonus: re-enabled the wizard test suite
`CreateMealWizard.test` had been `describe.skip` since Phase 1 *because of this very loop*. With the loop fixed (+ Google-Maps-layer mocks added), it runs and passes. **The whole client suite is now 7 files / 46 tests passed, 0 skipped.**

## Verification
- Headless browser: `/createMealWizard` renders, autocomplete mounts, **0** "Maximum update depth" errors (including after opening the map)
- `npm test`: **46 passed, 0 skipped** · `lint` 0 errors · `vite build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)